### PR TITLE
Feature/vpc endpoints - Add VPC Endpoints to Replace NAT

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,6 @@
 module "vpc_module" {
   source = "./modules/vpc"
+  ecs_task_sg_id       = var.ecs_task_sg_id
 }
 
 module "alb_module" {

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -14,12 +14,12 @@ resource "aws_internet_gateway" "igw" {
   }
 }
 
-resource "aws_eip" "nat_eip" {
-  count = 2
-  tags = {
-    Name = "team-echo-nat-eip-${count.index + 1}"
-  }
-}
+# resource "aws_eip" "nat_eip" {
+#   count = 2
+#   tags = {
+#     Name = "team-echo-nat-eip-${count.index + 1}"
+#   }
+# }
 
 resource "aws_subnet" "public" {
   count                   = 2
@@ -42,14 +42,14 @@ resource "aws_subnet" "private" {
   }
 }
 
-resource "aws_nat_gateway" "nat_gw" {
-  count         = 2
-  allocation_id = aws_eip.nat_eip[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
-  tags = {
-    Name = "team-echo-nat-${count.index + 1}"
-  }
-}
+# resource "aws_nat_gateway" "nat_gw" {
+#   count         = 2
+#   allocation_id = aws_eip.nat_eip[count.index].id
+#   subnet_id     = aws_subnet.public[count.index].id
+#   tags = {
+#     Name = "team-echo-nat-${count.index + 1}"
+#   }
+# }
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.vpc.id
@@ -78,15 +78,74 @@ resource "aws_route_table" "private" {
   }
 }
 
-resource "aws_route" "private_nat" {
-  count                   = 2
-  route_table_id         = aws_route_table.private[count.index].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.nat_gw[count.index].id
-}
+# resource "aws_route" "private_nat" {
+#   count                   = 2
+#   route_table_id         = aws_route_table.private[count.index].id
+#   destination_cidr_block = "0.0.0.0/0"
+#   nat_gateway_id         = aws_nat_gateway.nat_gw[count.index].id
+# }
 
 resource "aws_route_table_association" "private" {
   count          = 2
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[count.index].id
 }
+
+#Security group for VPC Endpoints
+resource "aws_security_group" "vpc_endpoints" {
+  name        = "team-echo-vpce-sg"
+  description = "Allow HTTPS from ECS task SG"
+  vpc_id      = aws_vpc.vpc.id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    # security_groups = [var.ecs_task_sg_id]
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "team-echo-vpce-sg"
+  }
+}
+
+#VPC Endpoints (ECR API, ECR DKR, S3 Gateway, Logs)
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id            = aws_vpc.vpc.id
+  service_name      = "com.amazonaws.${var.aws_region}.ecr.api"
+  vpc_endpoint_type = "Interface"
+  subnet_ids        = aws_subnet.private[*].id
+  security_group_ids = [aws_security_group.vpc_endpoints.id]
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = aws_vpc.vpc.id
+  service_name      = "com.amazonaws.${var.aws_region}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+  subnet_ids        = aws_subnet.private[*].id
+  security_group_ids = [aws_security_group.vpc_endpoints.id]
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id             = aws_vpc.vpc.id
+  service_name       = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type  = "Gateway"
+  route_table_ids    = aws_route_table.private[*].id
+}
+
+resource "aws_vpc_endpoint" "cloudwatch_logs" {
+  vpc_id            = aws_vpc.vpc.id
+  service_name      = "com.amazonaws.${var.aws_region}.logs"
+  vpc_endpoint_type = "Interface"
+  subnet_ids        = aws_subnet.private[*].id
+  security_group_ids = [aws_security_group.vpc_endpoints.id]
+}
+

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -10,6 +10,6 @@ output "private_subnet_ids" {
   value = aws_subnet.private[*].id
 }
 
-output "nat_gateway_ids" {
-  value = aws_nat_gateway.nat_gw[*].id
-}
+# output "nat_gateway_ids" {
+#   value = aws_nat_gateway.nat_gw[*].id
+# }

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -21,3 +21,15 @@ variable "private_subnet_cidrs" {
   type        = list(string)
   default     = ["10.0.1.0/24", "10.0.3.0/24"]
 }
+
+variable "aws_region" {
+  description = "AWS region for the VPC and endpoints"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "ecs_task_sg_id" {
+  description = "Security group ID for ECS tasks (used in VPC endpoint SG)"
+  type        = string
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "ecs_task_sg_id" {
+  description = "Security group ID for ECS tasks (used for VPC endpoint access)"
+  type        = string
+}


### PR DESCRIPTION
Add 3 VPC interface endpoints so ECS tasks can pull images from ECR without needing a NAT Gateway:
ecr.api
ecr.dkr
logs (CloudWatch)

Removed all NAT-related resources (NAT GW, EIPs, private route table routes to NAT)

Added a temporary SG rule to allow HTTPS from 0.0.0.0/0 — just for testing until we get the actual ECS task SG.

Tested with terraform apply

All endpoints deployed successfully in the private subnets
Summary from Terraform: 4 added, 0 changed, 1 destroyed

The destroyed resource was the original SG that got replaced due to the updated rule

Next we need to Swap the open SG rule with the actual ECS task SG once it's shared.

